### PR TITLE
update performance test to produce same result for both tests

### DIFF
--- a/stash/performance.nim
+++ b/stash/performance.nim
@@ -1,4 +1,4 @@
-import std/[hashes, times]
+import std/[hashes, times, monotimes]
 
 #
 # This is a performance comparison between CPS and native closure iterators.
@@ -11,14 +11,13 @@ when not defined(gcArc):
 
 import cps
 
-template howLong(what, code): float =
-  let start = cpuTime()
+template howLong(what, code): Duration =
+  let start = getMonoTime()
   block:
     code
-  let duration = cpuTime() - start
-  echo what, ": ", duration, " s"
+  let duration = getMonoTime() - start
+  echo what, ": ", duration
   duration
-
 
 const iterations = 1_000_000_000
 var h: Hash = 0
@@ -27,11 +26,21 @@ let t1 = howLong "cps iterator":
 
   type
     Iterator = ref object of Continuation
+      yielded: bool
       val: int
 
   proc jield(it: Iterator; val: int): Iterator {.cpsMagic.} =
+    it.yielded = true
     it.val = val
     return it
+
+  proc next(it: var Iterator): int =
+    while true:
+      it = Iterator it.fn(it)
+      if it.finished: break
+      if it.yielded:
+        it.yielded = false
+        return it.val
 
   proc counter(lo: int, hi: int) {.cps: Iterator.} =
     var i = lo
@@ -39,30 +48,35 @@ let t1 = howLong "cps iterator":
       jield i
       inc i
 
-  template finished(x: ref): bool = x == nil or x.fn == nil
-
   var a = Iterator: whelp counter(1, iterations)
-  while not finished(a):
-    h = h !& hash(a.val)
-    a = Iterator a.fn(a)
-
+  while true:
+    let next = a.next()
+    if a.finished: break
+    h = h !& hash(next)
 
 echo !$h
 h = 0
 
 let t2 = howLong "closure iterator":
 
-  iterator counter(lo: int, hi: int): int {.closure.} =
-    var i = lo
-    while i <= hi:
-      yield i
-      yield i
-      inc i
+  proc counter(lo: int, hi: int): iterator(): int =
+    result =
+      iterator (): int =
+        var i = lo
+        while i <= hi:
+          yield i
+          inc i
 
-  let f = counter
-  while not finished(f):
-    h = h !& hash(f(1, iterations))
+  let f = counter(1, iterations)
+  while true:
+    let next = f()
+    if f.finished: break
+    h = h !& hash(next)
 
 echo !$h
 
-echo "Nim closure iterators are ", t2 / t1, " times slower"
+let ratio = t2.inNanoseconds.float / t1.inNanoseconds.float
+if ratio < 1:
+  echo "Nim closure iterators are ", 1 / ratio, " times faster"
+else:
+  echo "Nim closure iterators are ", ratio, " times slower"


### PR DESCRIPTION
Main changes:
- `howLong` now uses `MonoTime` to calculate the diff. This is simpler and
  has less overhead than `cpuTime`, at least.
- `Iterator` gains a yielded marker to distinguish between regular jumps
  and `jield`, with a convienence `next()` proc to advance the iteration.
- Changed closure iterator test to one where the parameters are saved.
  This puts it inline with what cps does.
- Tweaked the termination condition so that it is checked after the
  iteration is run, this is because an iterator "finished" state changes
  after it is run, so using the numbers without checking if it's
  produced by the iterator or its the default due to the iterator ending
  is error prone.

Currently CPS is 3.5x slower than Nim, tested on an AMD Ryzen 5 3600.

Ref #243 