### PR TITLE
add support for converting a cps call result

### DIFF
--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -263,6 +263,15 @@ proc isCpsCall*(n: NormNode): bool =
         # or it could be a completely new continuation
         result = it.impl.hasPragma "cpsMustJump"
 
+proc isCpsConvCall*(n: NormNode): bool =
+  ## true if this node holds a cps call that might be nested within one or more
+  ## conversions.
+  case n.kind
+  of nnkConv:
+    isCpsConvCall(n.last)
+  else:
+    isCpsCall(n)
+
 proc isCpsBlock*(n: NormNode): bool =
   ## `true` if the block `n` contains a cps call anywhere at all;
   ## this is used to figure out if a block needs tailcall handling...

--- a/tests/treturns.nim
+++ b/tests/treturns.nim
@@ -196,3 +196,31 @@ suite "returns and results":
       check (x, y) == (10, 20)
 
     foo()
+
+  block:
+    ## converting a cps return value
+    var k = newKiller(3)
+
+    proc bar(): int {.cps: Cont.} =
+      noop()
+      42
+
+    proc foo() {.cps: Cont.} =
+      let x = Natural bar()
+      let x1 = Natural int Natural bar()
+
+      step 1
+      check x == 42
+
+      var y: Natural
+      y = Natural bar()
+      y = Natural int Natural bar()
+
+      step 2
+      check y == 42
+
+      discard Natural bar()
+      discard Natural int Natural bar()
+      step 3
+
+    foo()


### PR DESCRIPTION
Conversions are simple and side-effect free, so to support them in
assignments we only have to tweak the shim so that it look for the call
within the expression and replace it with the result.

For `discard`, we rewrite the statement into an assignment with a
temporary to simulate the effect since we cannot "skip" the conversion
due to their interactions with destructors.