### PR TITLE
rename `()` to `recover`

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,10 +430,6 @@ development](https://github.com/nim-lang/Nim/issues?q=is%3Aopen+is%3Aissue+label
 - Generic continuations such as the following won't work without changes to
 the compiler.
 
-- The `()` procedure can prevent compilation of `foo[T](bar)` call syntax;
-  `--define:cpsResultProc="someNameHere"` to specify an alternate identifier
-  for the `()` procedure.
-
 ```nim
 type
   MyContinuation[T] = ref object of Continuation

--- a/README.md
+++ b/README.md
@@ -430,6 +430,10 @@ development](https://github.com/nim-lang/Nim/issues?q=is%3Aopen+is%3Aissue+label
 - Generic continuations such as the following won't work without changes to
 the compiler.
 
+- The `()` procedure can prevent compilation of `foo[T](bar)` call syntax;
+  `--define:cpsResultProc="someNameHere"` to specify an alternate identifier
+  for the `()` procedure.
+
 ```nim
 type
   MyContinuation[T] = ref object of Continuation

--- a/cps.nim
+++ b/cps.nim
@@ -271,8 +271,6 @@ proc dealloc*[T: Continuation](c: sink T; E: typedesc[T]): E {.used, inline.} =
   ## its result may be assigned to another continuation reference.
   nil
 
-{.push experimental: "callOperator".}
-template `()`(c: Continuation): untyped {.used.} =
+template recover*(c: Continuation): untyped {.used.} =
   ## Returns the result, i.e. the return value, of a continuation.
   discard
-{.pop.}

--- a/cps.nimble
+++ b/cps.nimble
@@ -1,4 +1,4 @@
-version = "0.4.5"
+version = "0.5.0"
 author = "disruptek"
 description = "continuation-passing style"
 license = "MIT"

--- a/cps/transform.nim
+++ b/cps/transform.nim
@@ -624,7 +624,7 @@ proc shimAssign(env: var Env; store: NormNode, expr: NormNode, tail: NormNode): 
 
   # swap the call in the assignment statement(s)
   let (child, etype) = setupChildContinuation(env, call)
-  assign = assign.resymCall(call, newCall child)
+  assign = assign.resymCall(call, newCall("recover".asName, child))
 
   # compose the rewrite as an assignment, a lame effort to dealloc
   # the child, and then any remaining statements we were passed
@@ -1198,17 +1198,17 @@ proc cpsTransformProc(T: NimNode, n: NimNode): NormNode =
   for p in [whelp, booty]:
     p.addPragma(bindName"cpsEnvironment", env.identity)
 
-  # the `()` operator recovers the result of a continuation
+  # the `recover` operator recovers the result of a continuation
   #
   # copy the exported-ness from the original proc so that it can be used
   # from other modules
-  let dots = env.createResult(originalProcSym.isExported)
+  let recover = env.createRecover(exported = originalProcSym.isExported)
 
   # "encouraging" a write of the current accumulating type
   env = env.storeType(force = off)
 
   # generated proc bodies, remaining proc, whelp, bootstrap
-  result = newStmtList(types, processMainContinuation, dots, whelp, booty)
+  result = newStmtList(types, processMainContinuation, recover, whelp, booty)
 
   # this is something that happens a lot in cps-generated code, so hide it
   # here to not spam the user with hints.

--- a/tests/thooks.nim
+++ b/tests/thooks.nim
@@ -80,7 +80,7 @@ suite "hooks":
         stack 2: foo foo 👍
         boot 3: c nil 👍
         trace 4: foo continuation 👍
-        coop 5: Cont nil genasts.nim
+        coop 5: Cont nil environment.nim
         trace 6: While Loop continuation 👍
         trace 7: Post Call continuation 👍
         tail 8: Cont continuation 👍
@@ -92,9 +92,9 @@ suite "hooks":
         trace 14: Post Call continuation 👍
         pass 15: continuation.mom Cont(continuation) normalizedast.nim
         coop 16: result nil normalizedast.nim
-        dealloc 17: cps environment 😎 genasts.nim
+        dealloc 17: cps environment 😎 environment.nim
         trace 18: Post Child continuation normalizedast.nim
-        coop 19: Cont nil genasts.nim
+        coop 19: Cont nil environment.nim
         trace 20: While Loop continuation 👍
         trace 21: Post Call continuation 👍
         tail 22: Cont continuation 👍
@@ -106,9 +106,9 @@ suite "hooks":
         trace 28: Post Call continuation 👍
         pass 29: continuation.mom Cont(continuation) normalizedast.nim
         coop 30: result nil normalizedast.nim
-        dealloc 31: cps environment 😎 genasts.nim
+        dealloc 31: cps environment 😎 environment.nim
         trace 32: Post Child continuation normalizedast.nim
-        coop 33: Cont nil genasts.nim
+        coop 33: Cont nil environment.nim
         trace 34: While Loop continuation 👍
         trace 35: Post Call continuation 👍
       """.dedent(8).strip()

--- a/tests/treturns.nim
+++ b/tests/treturns.nim
@@ -45,8 +45,8 @@ suite "returns and results":
 
     var c = whelp foo(5)
     trampoline c
-    check "call operator works correctly":
-      c() == 25
+    check "recover operator works correctly":
+      recover(c) == 25
 
   block:
     ## assignments to the special result symbol work
@@ -134,8 +134,8 @@ suite "returns and results":
 
     var c = whelp foo()
     trampoline c
-    check "call operator works correctly":
-      c() == 6
+    check "recover operator works correctly":
+      6 == recover c
 
   block:
     ## discarding a continuation return value works


### PR DESCRIPTION
Also improves the trace output a tiny bit.