### PR TITLE
remove workaround for nim-lang/Nim#18411

### DIFF
--- a/cps/transform.nim
+++ b/cps/transform.nim
@@ -1084,12 +1084,8 @@ macro cpsHandleUnhandledException(contType: typed; n: typed): untyped =
           body
         except:
           cont.ex = getCurrentException()
-        # A continuation body created with makeContProc (which is all of
-        # them) will have a terminator in the body, thus this part can
-        # only be reached iff the except branch happened to deter the jump
-        #
-        # Workaround for https://github.com/nim-lang/Nim/issues/18411
-        return Continuation: unwind(contType(cont), cont.ex)
+          return Continuation: unwind(contType(cont), cont.ex)
+
       result = fnDef
 
   debugAnnotation cpsHandleUnhandledException, n:


### PR DESCRIPTION
The issue was that no-return control flow in an except branch can mess
up the exception stack to the point of crashing the program, hence the
workaround was to exploit the "always return" property of a
continuation body.

Now that the issue is fixed, we can get rid of this workaround for a
more correct implementation.