### PR TITLE
Mark the Continuation type as .acyclic. to keep orcs hands off it

### DIFF
--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -57,7 +57,7 @@ const
   traceDequeSize* {.intdefine, used.} = 4_096
 
 type
-  Continuation* = ref object of RootObj
+  Continuation* {.acyclic.} = ref object of RootObj
     fn*: proc(c: Continuation): Continuation {.nimcall.} ##
     ## The `fn` points to the next continuation leg.
     mom*: Continuation  ##


### PR DESCRIPTION
this should allow CPS to be used with orc.

This does need some more discussion before merging...
