### PR TITLE
recover() only runs against mutable continuations

### DIFF
--- a/cps.nim
+++ b/cps.nim
@@ -321,9 +321,14 @@ when cpsCallOperatorSupported and not defined cpsNoCallOperator:
   macro `()`*[C; R; P](callback: Callback[C, R, P]; arguments: varargs[typed]): R =
     ## Allows for natural use of call syntax to invoke a callback and
     ## recover its result in a single statement, inside a continuation.
-    let call = bindSym"call"
-    result = newCall(call, callback)
+    let call = macros.newCall(macros.bindSym"call", callback)
     for argument in arguments.items:
-      result.add argument
-    result = newCall(bindSym"recover", callback, result)
+      call.add argument
+    let mutable = genSymVar("continuation", callback.NormNode).NimNode
+    result = macros.newStmtList()
+    result.add:
+      macros.newTree nnkVarSection:
+        macros.newTree(nnkIdentDefs, mutable, newEmptyNode(), call)
+    result.add:
+      macros.newCall(macros.bindSym"recover", callback, mutable)
   {.pop.}

--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -76,7 +76,7 @@ type
   Callback*[C; R; P] = object
     fn*: P                            ##
     ## the bootstrap for continuation C
-    rs*: proc (c: sink C): R {.nimcall.}   ##
+    rs*: proc (c: var C): R {.nimcall.}   ##
     ## the result fetcher for continuation C
 
   TraceFrame* = object ## a record of where the continuation has been
@@ -619,7 +619,7 @@ proc cpsCallbackTypeDef*(tipe: NimNode, n: NimNode): NimNode =
   result = nnkBracketExpr.newTree(bindSym"Callback", tipe, r, p)
   result = workaroundRewrites result.NormNode
 
-proc recover*[C, R, P](callback: Callback[C, R, P]; continuation: C): R =
+proc recover*[C, R, P](callback: Callback[C, R, P]; continuation: var C): R =
   ## Using a `callback`, recover the `result` of the given `continuation`.
   ## This is equivalent to running `()` on a continuation which was
   ## created with `whelp` against a procedure call.

--- a/tests/tcc.nim
+++ b/tests/tcc.nim
@@ -57,8 +57,8 @@ suite "calling convention":
       result = x.float
 
     const cb = whelp foo
-    let c = cb.call(3)
-    let d = cb.call(5)
+    var c = cb.call(3)
+    var d = cb.call(5)
     check cb.recover(c) == 3.0
     check cb.recover(d) == 5.0
 
@@ -76,7 +76,7 @@ suite "calling convention":
 
     proc foo(c: ContCall) {.cps: Cont.} =
       step 1
-      let x = c.call(4)
+      var x = c.call(4)
       step 2
       check c.recover(x) == 8
       step 4
@@ -88,10 +88,11 @@ suite "calling convention":
     when not cpsCallOperatorSupported:
       skip "unsupported on nim " & NimVersion
     else:
-      var k = newKiller 3
 
       type
         ContCall = proc(a: int): int {.cps: Cont.}
+
+      var k = newKiller 3
 
       proc bar(a: int): int {.cps: Cont.} =
         noop()
@@ -119,7 +120,7 @@ suite "calling convention":
     const
       cb: Callback = whelp bar
 
-    let x: C = cb.call(2)
-    let y: C = cb.call(4)
+    var x: C = cb.call(2)
+    var y: C = cb.call(4)
     check cb.recover(x) == 4.0
     check cb.recover(y) == 8.0


### PR DESCRIPTION
Since we currently trampoline continuations in order to recover results, such recovery can only occur on a mutable continuation.