### PR TITLE
recursive dependency: 'cpsJump'

### DIFF
--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -244,7 +244,7 @@ template rewriteIt*(n: typed; body: untyped): NormNode =
   body
   workaroundRewrites it
 
-template debugAnnotation*(s: typed; n: NimNode; body: untyped) {.dirty.} =
+template debugAnnotation*(s: untyped; n: NimNode; body: untyped) {.dirty.} =
   debug(astToStr s, n, Original)
   result = rewriteIt n:
     body


### PR DESCRIPTION
Caused by https://github.com/nim-lang/Nim/commit/63d29ddd6980ee9f89673c454c15da52e2984283 PR: https://github.com/nim-lang/Nim/pull/21671
Without this patch, attempting to build [disruptek/balls@#v4](https://github.com/disruptek/balls/tree/v4) gives
```shell
cps/transform.nim(70, 19) Error: recursive dependency: 'cpsJump'
Error: Build failed for the package: balls
```
https://github.com/nim-works/cps/blob/5645eb5838e6d30d484fbe23d8c590201e520630/cps/transform.nim#L70