### PR TITLE
make sure normalization is applied on identdefs value and cps calls

### DIFF
--- a/cps/rewrites.nim
+++ b/cps/rewrites.nim
@@ -154,7 +154,8 @@ proc normalizingRewrites*(n: NimNode): NormNode =
             for d in defs[0 .. ^3].items: # last two nodes are type and rhs
               result.add:
                 newNimNode(n.kind, n).add:
-                  newIdentDefs(d, copyNimTree(defs[^2]), copyNimTree(defs[^1]))
+                  newIdentDefs(d, copyNimTree(defs[^2])):
+                    normalizingRewrites(defs[^1])
           else:
             result.add:
               NimNode child.errorAst "unexpected"

--- a/cps/transform.nim
+++ b/cps/transform.nim
@@ -80,7 +80,7 @@ macro cpsContinuationJump(cont, contType: typed; name: static[string];
   ## a jump to another continuation that must be instantiated
   let
     c = c.NormNode                                      # store child here
-    call = asCall(NormNode call)                        # child bootstrap call
+    call = normalizeCall(call)                          # child bootstrap call
     name = genProcName(name, "child " & $call.name & "()",
                        info = n.NormNode)
     cont = cont.asName                                  # current continuation

--- a/tests/t40_ast.nim
+++ b/tests/t40_ast.nim
@@ -494,3 +494,20 @@ suite "tasteful tests":
 
     foo()
     check r == 2
+
+  block:
+    ## initializing a variable with calls containing object variant access
+    type
+      O = object
+        case switch: bool
+        of true: x: int
+        else: nil
+
+    func bar(x: int): int = x
+
+    proc foo() {.cps: Continuation.} =
+      let o = O(switch: true, x: 1)
+      let x = bar(o.x)
+      check x == 1
+
+    foo()

--- a/tests/t60_returns.nim
+++ b/tests/t60_returns.nim
@@ -220,3 +220,18 @@ suite "returns and results":
       step 3
 
     foo()
+
+  block:
+    ## calling continuation with variant object access as parameter
+    type
+      O = object
+        case switch: bool
+        of true: x: int
+        of false: discard
+
+    proc bar(x: int): int {.cps: Continuation.} = x
+
+    proc foo(o: O) {.cps: Continuation.} =
+      check bar(o.x) == 42
+
+    foo(O(switch: true, x: 42))


### PR DESCRIPTION
Added missing application of normalization on `IdentDefs` and calls during `cpsContinuationJump`

Fixes #301