### PR TITLE
experimental cps detection via scope injection

### DIFF
--- a/cps/normalizedast.nim
+++ b/cps/normalizedast.nim
@@ -267,7 +267,7 @@ defineToNimNodeConverter(
 allowAutoDowngradeNormalizedNode(
     Name, TypeExpr, Call, Conv, PragmaStmt, PragmaAtom, IdentDef, RoutineDef,
     ProcDef, FormalParams, RoutineParam, VarSection, LetSection, VarLet,
-    VarLetIdentDef, VarLetTuple, DefVarLet, IdentDefLet, Sym
+    VarLetIdentDef, VarLetTuple, DefVarLet, IdentDefLet, Sym, PragmaBlock
   )
 
 # types that go from a specific type to a less specific type, "downgrade"

--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -50,6 +50,7 @@ template cpsTerminate*() {.pragma.}     ## this is the end of this procedure
 template cpsHasException*(cont, ex: typed) {.pragma.}  ##
 ## the continuation has an exception stored in `ex`, with `cont` being the
 ## continuation symbol used.
+template cpsExtract*() {.pragma.} ## extract this block from the scope
 
 const
   cpsStackFrames* {.booldefine, used.} = compileOption"stacktrace"

--- a/cps/transform.nim
+++ b/cps/transform.nim
@@ -975,6 +975,13 @@ macro cpsFloater(n: typed): untyped =
   result = floater:
     copyNimTree n
 
+macro cpsScalpel*(n: typed): untyped =
+  ## returns the first `{.cpsExtract.}` block from `n`
+  debugAnnotation cpsScalpel, n:
+    it = it.findChildRecursive() do (n: NormNode) -> bool:
+      n.kind == nnkPragmaBlock and n.asPragmaBlock().hasPragma("cpsExtract")
+    it = it.last
+
 macro cpsManageException(name: static[string]; n: typed): untyped =
   ## rewrites all continuations in `n` containing an exception so that exception
   ## become the "current" exception of that continuation while preserving the


### PR DESCRIPTION
This employs the use of a "phantom" scope to inject new symbols into the body of a cps block before they are semantically checked.

After that, we surgically extract the transformed output, lifting the result from the phantom scope to the invocation scope.

The experiment currently injects a single symbol: `isInCps`, which would allow macros/template to detect if they are in cps scope.

This stuff doesn't build yet, a simple:

```nim
proc foo() {.cps: Continuation.} = discard
```

fails with:

```
cps/cps.nim(245, 41) Error: inconsistent typing for reintroduced symbol 'continuation': previous type was: cps:foo() env; new type is: cps:foo() env
```

on NimSkull.