### PR TITLE
perform a missing dealloc() in bootstrap

### DIFF
--- a/cps.nim
+++ b/cps.nim
@@ -310,7 +310,8 @@ proc dealloc*[T: Continuation](c: sink T; E: typedesc[T]): E {.used, inline.} =
   ## `c` is the continuation to be deallocated, while `E` is the type of
   ## its environment.  This procedure should generally return `nil`, as
   ## its result may be assigned to another continuation reference.
-  disarm c
+  if not c.dismissed:
+    disarm c
 
 template recover*(c: Continuation): untyped {.used.} =
   ## Returns the result, i.e. the return value, of a continuation.

--- a/cps/environment.nim
+++ b/cps/environment.nim
@@ -576,24 +576,22 @@ proc createBootstrap*(env: Env; n: ProcDef, goto: NormNode): ProcDef =
   elif env.rs.hasType:
     result.body.add:
       # then at runtime, issue an if statement to
-      nnkIfExpr.newTree:
+      nnkIfStmt.newTree:
         nnkElifExpr.newTree(
           # check if the continuation is not nil, and if so, to
           newCall(bindSym"not", newDotExpr(c, asName"dismissed")),
           # assign the result from the continuation's result field
           newAssignment(asName"result",
                         newCall(ident"move",
-                        newDotExpr(env.castToChild(c), env.rs.name)).NormNode)
-        )
+                        newDotExpr(env.castToChild(c), env.rs.name)).NormNode))
   # perform a dealloc() on the continuation if we can
   result.body.add:
-    nnkIfExpr.newTree:
+    nnkIfStmt.newTree:
       nnkElifExpr.newTree(
         # check if the continuation is not nil, and if so, to
         newCall(bindSym"not", newDotExpr(c, asName"dismissed")),
         # apply the dealloc() hook on the continuation
-        newAssignment(c, Dealloc.hook(env.castToRoot(c), env.identity))
-      )
+        newAssignment(c, Dealloc.hook(env.castToRoot(c), env.identity)))
 
 proc rewriteVoodoo*(env: Env; n: NormNode): NormNode =
   ## Rewrite non-yielding cpsCall calls by inserting the continuation as

--- a/cps/environment.nim
+++ b/cps/environment.nim
@@ -541,7 +541,7 @@ proc createBootstrap*(env: Env; n: ProcDef, goto: NormNode): ProcDef =
   result = clone(n, newStmtList())
   result.addPragma "used"  # avoid gratuitous warnings
   result.addPragma "nimcall"
-  result.introduce {Alloc, Boot, Stack}
+  result.introduce {Alloc, Boot, Stack, Dealloc}
 
   let c = genSymVar("c", info = n)
   result.body.add:
@@ -582,8 +582,18 @@ proc createBootstrap*(env: Env; n: ProcDef, goto: NormNode): ProcDef =
           newCall(bindSym"not", newDotExpr(c, asName"dismissed")),
           # assign the result from the continuation's result field
           newAssignment(asName"result",
-            newDotExpr(env.castToChild(c), env.rs.name))
+                        newCall(ident"move",
+                        newDotExpr(env.castToChild(c), env.rs.name)).NormNode)
         )
+  # perform a dealloc() on the continuation if we can
+  result.body.add:
+    nnkIfExpr.newTree:
+      nnkElifExpr.newTree(
+        # check if the continuation is not nil, and if so, to
+        newCall(bindSym"not", newDotExpr(c, asName"dismissed")),
+        # apply the dealloc() hook on the continuation
+        newAssignment(c, Dealloc.hook(env.castToRoot(c), env.identity))
+      )
 
 proc rewriteVoodoo*(env: Env; n: NormNode): NormNode =
   ## Rewrite non-yielding cpsCall calls by inserting the continuation as

--- a/tests/t50_hooks.nim
+++ b/tests/t50_hooks.nim
@@ -117,6 +117,7 @@ suite "hooks":
           coop: Cont nil environment.nim
           trace: cps:foo() loop continuation 👍
           trace: cps:foo() jump noop() continuation 👍
+          dealloc: cps:foo() env 😎 👍
         """
     else:
       const
@@ -154,16 +155,26 @@ suite "hooks":
           coop: Cont nil environment.nim
           trace: cps:foo() loop continuation 👍
           trace: cps:foo() jump noop() continuation 👍
+          dealloc: cps:foo() env 😎 👍
         """
     let x = expected.normalize
     let y = s.normalize
     if x != y:
-      var i = 0
-      for (a, b) in zip(x, y).items:
-        if a != b:
-          checkpoint "#", i, " < ", a
-          checkpoint "#", i, " > ", b
-        inc i
+      if x.len != y.len:
+        checkpoint "expected:"
+        for n in x.items:
+          checkpoint n
+        checkpoint "\n"
+        checkpoint "received:"
+        for n in y.items:
+          checkpoint n
+      else:
+        var i = 0
+        for (a, b) in zip(x, y).items:
+          if a != b:
+            checkpoint "#", i, " < ", a
+            checkpoint "#", i, " > ", b
+          inc i
       fail "trace output doesn't match"
 
   block:
@@ -182,9 +193,9 @@ suite "hooks":
 
   block:
     ## custom continuation deallocators can nil the continuation
-    shouldRun 4:
+    shouldRun 5:
       proc dealloc[T: Cont](c: sink T; E: typedesc[T]): E =
-        ran()
+        ran()    # (runs twice)
         c = nil
 
       proc bar() {.cps: Cont.} =


### PR DESCRIPTION
Unfortunately, this is really just a partial solution to making alloc/dealloc work more widely.  The hook might just be poorly conceived.