### PR TITLE
make cps work with new nimskull again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,10 +64,10 @@ jobs:
 
           - name: nimskull
             version: "*"
-            broken: true
+            broken: false
 
           - name: nimskull
-            version: "<0.1.0-dev.21268"
+            version: "0.1.0-dev.21407"
             broken: false
 
     name: "${{ matrix.os }} (${{ matrix.compiler.name }} ${{ matrix.compiler.version }}${{ matrix.compiler.broken && ', broken' || '' }})"

--- a/cps/spec.nim
+++ b/cps/spec.nim
@@ -5,7 +5,7 @@ boring utilities likely useful to multiple pieces of cps machinery
 ]##
 
 import std/[hashes, sequtils, deques]
-import std/macros except newStmtList, newTree
+import std/macros except newStmtList, newTree, quote, stamp
 
 when (NimMajor, NimMinor) < (1, 5):
   {.fatal: "requires nim-1.5".}
@@ -98,6 +98,14 @@ proc `=copy`(dest: var ContinuationObj; src: ContinuationObj) {.error.} =
 proc `=destroy`(dest: var ContinuationObj) =
   for key, value in dest.fieldPairs:
     reset value
+
+# quote() shim for nimskull
+when declared(macros.stamp):
+  template quote(body: untyped): NimNode =
+    macros.stamp(body)
+else:
+  template quote(body: untyped): NimNode =
+    macros.quote(body)
 
 template dot*(a, b: NimNode): NimNode =
   ## for constructing foo.bar

--- a/tests/killer.nim
+++ b/tests/killer.nim
@@ -6,20 +6,32 @@ type
     final: int
     n: int
 
-proc `=destroy`*(k: var Killer) {.raises: [FailError].} =
+proc failMsg(k: Killer): string =
+  case k.n
+  of 0: "uninitialized"
+  of 1: "unused"
+  else: "misused; " & $(k.n - 1) & " uses, expected " & $(k.final - 1)
+
+proc `=destroy`*(k: var Killer) {.raises: [].} =
+  ## Raise a `Defect` if `k` has errors.
+  ##
+  ## `check()` should be used to have errors raised as test failures.
+  ##
+  ## This destructor is a last-ditch effort for when `check()` is not
+  ## run.
+  # Only crash if there's no exception running
+  if k.final != k.n and getCurrentException() == nil:
+    raise newException(Defect, k.failMsg)
+
+proc check*(k: Killer) {.raises: [FailError].} =
+  ## Check `k` for errors.
   if k.final != k.n:
-    let e = getCurrentException()
-    # don't obliterate current exception
-    when defined(ExpectedError):
-      let shouldFail = e.isNil or e isnot FailError or e isnot ExpectedError
-    else:
-      let shouldFail = e.isNil or e isnot FailError
-    if shouldFail:
-      fail:
-        case k.n
-        of 0: "uninitialized"
-        of 1: "unused"
-        else: "misused; " & $(k.n - 1) & " uses, expected " & $(k.final - 1)
+    fail k.failMsg
+
+proc clear*(k: var Killer) =
+  ## Clear and defuse `k`. `k` is not reusable after this.
+  k.final = 0
+  k.n = 0
 
 proc initKiller*(final = 1): Killer =
   Killer(n: 1, final: final + 1)
@@ -31,7 +43,15 @@ proc newKiller*(final = 1): Killer =
 proc inc*(k: var Killer) = system.inc k.n
 template step*(k: Killer): int = k.n - 1
 
-template step*(i: int) {.dirty.} =
+template step*(k: var Killer, i: int) =
+  bind check
+
   check k.n == i, "expected step " & $k.n & " but hit " & $i
   inc k.n
   k.final = max(i, k.final)
+
+template step*(i: int) =
+  mixin k
+  bind step
+
+  step k, i

--- a/tests/t10_loops.nim
+++ b/tests/t10_loops.nim
@@ -182,3 +182,4 @@ suite "loops":
         break
         step 7
     foo()
+    check k

--- a/tests/t20_api.nim
+++ b/tests/t20_api.nim
@@ -16,6 +16,7 @@ suite "cps api":
     var i = bootstrap()
     check i is int, "bootstrap's output is not an int"
     check i == 3, "bootstrap's output has the wrong value"
+    check k
 
   block:
     ## whelp
@@ -29,6 +30,7 @@ suite "cps api":
     var c = whelp whelped()
     check "whelp's output is bogus":
       c is Cont
+    check k
 
   block:
     ## state symbols and trampoline
@@ -51,6 +53,7 @@ suite "cps api":
       c.state == State.Finished
       c.finished
       not c.running
+    check k
 
   block:
     ## trampolineIt
@@ -69,6 +72,7 @@ suite "cps api":
     check "state post-trampolineIt is " & $c.state:
       not c.dismissed
       c.finished
+    check k
 
   block:
     ## magic voodoo
@@ -99,6 +103,7 @@ suite "cps api":
       return 3
 
     check foo() == 3
+    check k
 
   block:
     ## exporting CPS procedures works
@@ -113,6 +118,7 @@ suite "cps api":
       step 2
 
     foo()
+    check k
 
   block:
     ## one can whelp a cps'd proc that was borrowed
@@ -146,6 +152,7 @@ suite "cps api":
       step 3
 
     foo()
+    check k
 
   block:
     ## calling magic that is not defined for the base type should not compile
@@ -158,25 +165,23 @@ suite "cps api":
 
   block:
     ## calling magic/voodoo with generics continuation parameter works
-    # XXX: Not sure why, but Killer doesn't work here, complaining about
-    #      `k` not in scope.
-    var r = 0
+    var k = newKiller 3
 
     type AnotherCont = ref object of Continuation
     proc magic(c: Cont or AnotherCont): auto {.cpsMagic.} =
-      inc r
+      k.step 3
       c
 
     proc voodoo(c: Cont or AnotherCont) {.cpsVoodoo.} =
-      inc r
+      k.step 2
 
     proc foo() {.cps: Cont.} =
-      inc r
+      step 1
       voodoo()
       magic()
 
     foo()
-    check r == 3
+    check k
 
   block:
     ## magic/voodoo can be defined with `using`
@@ -209,6 +214,7 @@ suite "cps api":
         return 3
 
       check foo() == 3
+      check k
 
   block:
     ## parent-child voodoo works correctly
@@ -245,3 +251,4 @@ suite "cps api":
 
     var a = whelp level_one()
     trampoline a
+    check k

--- a/tests/t30_cc.nim
+++ b/tests/t30_cc.nim
@@ -92,6 +92,7 @@ suite "calling convention":
       step 7
 
     foo: whelp bar
+    check k
 
   block:
     ## whelp helps disambiguate cps callbacks at instantiation
@@ -116,6 +117,7 @@ suite "calling convention":
       check x == 8
 
     foo: whelp(ContCall, bar)
+    check k
 
   block:
     ## run a callback in cps with natural syntax
@@ -140,6 +142,7 @@ suite "calling convention":
         step 3
 
       foo: whelp bar
+      check k
 
   block:
     ## run a callback with no return value in cps
@@ -162,6 +165,7 @@ suite "calling convention":
         step 3
 
       foo: whelp bar
+      check k
 
   block:
     ## callback illustration

--- a/tests/t50_hooks.nim
+++ b/tests/t50_hooks.nim
@@ -334,3 +334,4 @@ suite "hooks":
 
     expect IOError:
       foo()
+    check k

--- a/tests/t60_returns.nim
+++ b/tests/t60_returns.nim
@@ -19,6 +19,7 @@ suite "returns and results":
       check x == 8
 
     foo()
+    check k
 
   block:
     ## continuations can return values via bootstrap
@@ -30,6 +31,7 @@ suite "returns and results":
 
     let x = foo(3)
     check x == 9
+    check k
 
   block:
     ## continuations can return values via whelp
@@ -43,6 +45,7 @@ suite "returns and results":
     trampoline c
     check "recover operator works correctly":
       recover(c) == 25
+    check k
 
   block:
     ## assignments to the special result symbol work
@@ -55,6 +58,7 @@ suite "returns and results":
 
       let x = foo(3)
       check x == 9
+      check k
 
     block:
       var k = newKiller 1
@@ -65,6 +69,7 @@ suite "returns and results":
 
       var c = whelp foo(5)
       trampoline c
+      check k
 
   block:
     ## naked returns in continuations with a complication are fine
@@ -77,6 +82,7 @@ suite "returns and results":
       step 2
 
     foo()
+    check k
 
   block:
     ## dismissing a child continuation is fun
@@ -94,6 +100,7 @@ suite "returns and results":
       check x == 8
 
     foo()
+    check k
 
   block:
     ## assignment to a continuation return value
@@ -111,6 +118,7 @@ suite "returns and results":
       check x == 8
 
     foo()
+    check k
 
   block:
     ## local assignment tuple unpacking a continution return value
@@ -132,6 +140,7 @@ suite "returns and results":
     trampoline c
     check "recover operator works correctly":
       6 == recover c
+    check k
 
   block:
     ## discarding a continuation return value works
@@ -145,6 +154,7 @@ suite "returns and results":
       step 2
 
     foo()
+    check k
 
   block:
     ## returning a continuation return value works
@@ -157,6 +167,7 @@ suite "returns and results":
       return bar()
 
     check foo() == "test"
+    check k
 
   block:
     ## returning an anonymous tuple declaration type
@@ -173,6 +184,7 @@ suite "returns and results":
       check (x, y) == (10, 20)
 
     foo()
+    check k
 
   block:
     ## returning a named tuple type
@@ -192,6 +204,7 @@ suite "returns and results":
       check (x, y) == (10, 20)
 
     foo()
+    check k
 
   block:
     ## converting a cps return value
@@ -220,6 +233,7 @@ suite "returns and results":
       step 3
 
     foo()
+    check k
 
   block:
     ## calling continuation with variant object access as parameter

--- a/tests/t70_locals.nim
+++ b/tests/t70_locals.nim
@@ -403,7 +403,8 @@ suite "tuples":
     check r == 2
 
 type
-  K = distinct object
+  KObj = object
+  K = distinct KObj
 
 var k = initKiller 9
 
@@ -463,6 +464,7 @@ suite "lifetimes":
         # destroy bar.m; eg. step == 11
 
       foo()
+      check k
 
   block:
     ## lifetime canary for distinct objects
@@ -501,6 +503,7 @@ suite "lifetimes":
       # destroy bar.m; eg. step == 9
 
     foo()
+    check k
 
 import std/sugar
 

--- a/tests/t80_try2.nim
+++ b/tests/t80_try2.nim
@@ -34,6 +34,7 @@ suite "try statements":
       step 6
 
     trampoline whelp(foobar())
+    check k
 
   block:
     ## try statement with a single statement which is a cps assignment
@@ -53,6 +54,7 @@ suite "try statements":
       check x == 42
 
     trampoline whelp(foo())
+    check k
 
   block:
     ## try-finally-reraise escape via break statements.
@@ -71,6 +73,7 @@ suite "try statements":
 
     expect ValueError:
       trampoline whelp(foo())
+    check k
 
   block:
     ## try-finally-reraise escape via continue statements.
@@ -89,6 +92,7 @@ suite "try statements":
 
     expect ValueError:
       trampoline whelp(foo())
+    check k
 
   block:
     ## try: raise() except: continue
@@ -110,6 +114,7 @@ suite "try statements":
         fail "uncaught exception"
 
     trampoline whelp(foo())
+    check k
 
   block:
     ## try-finally-reraise escape via return statements.
@@ -126,6 +131,7 @@ suite "try statements":
 
     expect ValueError:
       trampoline whelp(foo())
+    check k
 
   block:
     ## try-finally-reraise handle after escape attempt
@@ -144,6 +150,7 @@ suite "try statements":
         step 2
 
     trampoline whelp(foo())
+    check k
 
   block:
     ## the stack trace probably still works
@@ -267,6 +274,7 @@ when defined(gcArc) or defined(gcOrc):
         except CatchableError:
           fail "this branch should not run"
         step 3
+        check k
 
       foo()
 
@@ -283,6 +291,7 @@ when defined(gcArc) or defined(gcOrc):
         except CatchableError:
           step 3
         step 4
+        check k
 
       foo()
 
@@ -297,6 +306,7 @@ when defined(gcArc) or defined(gcOrc):
         finally:
           step 3
         step 4
+        check k
 
       foo()
 
@@ -315,5 +325,6 @@ when defined(gcArc) or defined(gcOrc):
         finally:
           step 4
         step 5
+        check k
 
       foo()

--- a/tests/t90_exprs1.nim
+++ b/tests/t90_exprs1.nim
@@ -15,6 +15,7 @@ suite "expression flattening":
       check b == y
 
     foo()
+    check k
 
   test "flatten block expression":
     var k = newKiller(3)
@@ -30,6 +31,7 @@ suite "expression flattening":
       check x == 42
 
     foo()
+    check k
 
   test "flatten if expression":
     var k = newKiller(5)
@@ -67,6 +69,7 @@ suite "expression flattening":
       check y == 30
 
     foo()
+    check k
 
   test "flatten case expression":
     var k = newKiller(3)
@@ -96,6 +99,7 @@ suite "expression flattening":
       check x == 42
 
     foo()
+    check k
 
   test "flatten try statement":
     var k = newKiller(4)
@@ -123,6 +127,7 @@ suite "expression flattening":
       check x == 42
 
     foo()
+    check k
 
   test "flatten if condition":
     var k = newKiller(5)
@@ -141,3 +146,4 @@ suite "expression flattening":
       step 5
 
     foo()
+    check k

--- a/tests/t90_exprs2.nim
+++ b/tests/t90_exprs2.nim
@@ -17,6 +17,7 @@ suite "expression flattening":
       step 4
 
     foo()
+    check k
 
   test "flatten case elif branches":
     var k = newKiller(4)
@@ -36,6 +37,7 @@ suite "expression flattening":
       step 4
 
     foo()
+    check k
 
   test "flatten while condition":
     var k = newKiller(4)
@@ -49,6 +51,7 @@ suite "expression flattening":
       step 4
 
     foo()
+    check k
 
   test "flatten assignments with LHS being a symbol":
     var k = newKiller(3)
@@ -69,6 +72,7 @@ suite "expression flattening":
       check x == 42
 
     foo()
+    check k
 
   test "flatten assignments with LHS being an object access":
     type
@@ -95,6 +99,7 @@ suite "expression flattening":
       check o.a.i == 42
 
     foo()
+    check k
 
   test "flatten assignments with LHS being a ref access from immutable location":
     type
@@ -121,3 +126,4 @@ suite "expression flattening":
       check o.a.i == 42
 
     foo()
+    check k

--- a/tests/t90_exprs3.nim
+++ b/tests/t90_exprs3.nim
@@ -26,6 +26,7 @@ suite "expression flattening":
       check o.y == 10
 
     foo()
+    check k
 
   test "flatten upcasting assignments":
     when not defined(release) and not defined(isNimSkull):
@@ -57,6 +58,7 @@ suite "expression flattening":
         check o.y == 10
 
       foo()
+      check k
 
   test "flatten implicitly converted assignments":
     var k = newKiller(3)
@@ -76,6 +78,7 @@ suite "expression flattening":
       check o == 42
 
     foo()
+    check k
 
   test "flatten explicitly converted assignments":
     var k = newKiller(3)
@@ -88,6 +91,7 @@ suite "expression flattening":
       check i == 42
 
     foo()
+    check k
 
   test "flatten discard statements":
     var k = newKiller(3)
@@ -98,6 +102,7 @@ suite "expression flattening":
       step 3
 
     foo()
+    check k
 
   test "flatten return statements":
     var k = newKiller(2)
@@ -106,3 +111,4 @@ suite "expression flattening":
       return (block: (noop(); step 2; 42.Natural))
 
     check foo() == 42
+    check k

--- a/tests/t90_exprs4.nim
+++ b/tests/t90_exprs4.nim
@@ -12,6 +12,7 @@ suite "expression flattening":
       check x == [1, 2, 42, 10, 20]
 
     foo()
+    check k
 
   test "flatten tuple construction":
     var k = newKiller(5)
@@ -27,6 +28,7 @@ suite "expression flattening":
       check x == (1, 2, 42, 10, 20)
 
     foo()
+    check k
 
   test "flatten object construction":
     type
@@ -46,6 +48,7 @@ suite "expression flattening":
       check x == O(x: 42, y: 10, z: 20)
 
     foo()
+    check k
 
   test "flatten calls":
     var k = newKiller(5)
@@ -69,6 +72,7 @@ suite "expression flattening":
       barvar(x, (noop(); step 4; x = 20; x))
 
     foo()
+    check k
 
   test "flatten and/or with short circuiting":
     var k = newKiller(7)
@@ -81,6 +85,7 @@ suite "expression flattening":
       check (noop(); step 7; true) or (noop(); fail "this should not run"; false)
 
     foo()
+    check k
 
   test "flatten raise statement":
     var k = newKiller(3)
@@ -94,3 +99,4 @@ suite "expression flattening":
         check e.msg == "test"
 
     foo()
+    check k

--- a/tests/t90_exprs5.nim
+++ b/tests/t90_exprs5.nim
@@ -16,6 +16,7 @@ suite "expression flattening":
       check x == 10
 
     foo()
+    check k
 
   test "flatten result expressions":
     var k = newKiller(1)
@@ -25,6 +26,7 @@ suite "expression flattening":
       42.Natural
 
     check foo() == 42
+    check k
 
   test "flatten bracket expressions (array access)":
     var k = newKiller(2)
@@ -33,6 +35,7 @@ suite "expression flattening":
       check (noop(); step 1; [42])[(noop(); step 2; 0)] == 42
 
     foo()
+    check k
 
   test "flatten dot expressions":
     type
@@ -45,6 +48,7 @@ suite "expression flattening":
       check (noop(); step 1; P(val: 42)).val == 42
 
     foo()
+    check k
 
   test "flatten dereference expressions":
     type
@@ -57,6 +61,7 @@ suite "expression flattening":
       check (noop(); step 1; P(val: 42))[].val == 42
 
     foo()
+    check k
 
   test "flatten hidden dereference expressions":
     type
@@ -69,6 +74,7 @@ suite "expression flattening":
       check (noop(); step 1; P(val: 42)).val == 42
 
     foo()
+    check k
 
   test "flatten magic calls with mutable variables":
     var k = newKiller(3)
@@ -87,3 +93,4 @@ suite "expression flattening":
       step 3
 
     foo()
+    check k


### PR DESCRIPTION
- Updated `killer` to deal with new `=destroy` constraints due to https://github.com/nim-works/nimskull/pull/1236
- Added shim for `quote` changes due to https://github.com/nim-works/nimskull/pull/1393
- Pin CI NimSkull to the (at the time of writing) latest version and mark latest as not broken