### PR TITLE
normalizedast: hide newTree from std/macros

### DIFF
--- a/cps/normalizedast.nim
+++ b/cps/normalizedast.nim
@@ -1,4 +1,4 @@
-import std/macros
+import std/macros except newTree
 import std/strformat
 from std/hashes import Hash, hash
 from std/sequtils import anyIt, toSeq


### PR DESCRIPTION
Whatever Nim merged recently caused macros.newTree to have higher precedence against newTree defined on NormNode within normalizedast.

As a workaround, don't import macros.newTree. This should fix Nim 2.0 support.