### PR TITLE
transform: rewrite result/return before annotate

### DIFF
--- a/cps/transform.nim
+++ b/cps/transform.nim
@@ -847,16 +847,6 @@ proc annotate(parent: var Env; n: NormNode): NormNode =
           endAndReturn()
 
     case nc.kind
-    of nnkReturnStmt:
-      # add a return statement with a potential result assignment
-      # stored in the environment; note that we're adding a new
-      # return statement without regard to the contents of `result`
-      # because it may hold, eg. `ElifBranch ...` or similar.
-      result.add:
-        env.annotate:
-          env.rewriteReturn nc
-      endAndReturn()
-
     of nnkVarSection, nnkLetSection:
       let section = asVarLet nc
       if section.val.isCpsConvCall:
@@ -1258,8 +1248,8 @@ proc cpsTransformProc(tipe: NimNode, n: NimNode): NormNode =
     Trace.hook env.first, n    # hooking against the proc (minus cloned body)
   body.add n.body              # add in the cloned body of the original proc
 
-  # replace the result symbols with the environment's result field
-  body = env.rewriteResult body
+  # rewrite return statements and result symbols to use environment's result field
+  body = env.rewriteResultReturn body
 
   # perform sym substitutions (or whatever)
   n.body = env.rewriteSymbolsIntoEnvDotField body

--- a/tests/t40_ast.nim
+++ b/tests/t40_ast.nim
@@ -511,3 +511,18 @@ suite "tasteful tests":
       check x == 1
 
     foo()
+
+  block:
+    ## don't rewrite return or result of nested procedures
+    proc foo() {.cps: Continuation.} =
+      proc other(): int = return 100
+
+      check other() == 100
+
+    proc bar() {.cps: Continuation.} =
+      proc other2(): int =
+        result = 2
+
+      check other2() == 2
+
+    foo()


### PR DESCRIPTION
Previously we unconditionally rewrite `return` with the assumption that all return belongs to the procedure being rewritten. This does not hold when nested procedures are used. This issue was exposed thanks to https://github.com/nim-works/nimskull/pull/1503 breaking an implicit dependency on the compiler's automatic result transformation for implicit returns.

This commit separate return rewrite from annotate and merge it with the result rewrite, as both require awareness of nested procedures.